### PR TITLE
use types in order given

### DIFF
--- a/lib/lib.go
+++ b/lib/lib.go
@@ -48,7 +48,7 @@ func GetName(types []string, separator string, randomNumer bool) (string, error)
 	}
 
 	var name []string
-	for t := range perms {
+	for _, t := range types {
 		thing := perms[t][ran(len(perms[t]))]
 		name = append(name, thing)
 	}


### PR DESCRIPTION
Prior to this change `name-generator -t 'colours,trees'` could generate both `pancho-moosewood` and `moosewood-pancho`. Now of the two only pancho-moosewood will be generated.