### PR TITLE
Fix formatting of allowed values

### DIFF
--- a/lib/lib.go
+++ b/lib/lib.go
@@ -34,7 +34,7 @@ func CheckType(types []string) error {
 	}
 	for _, t := range types {
 		if !contains(allTypes, t) {
-			return fmt.Errorf("type %s is not valid. Possible values are: %s", t, strings.Join(allTypes, ", `"))
+			return fmt.Errorf("type %s is not valid. Possible values are: `%s`", t, strings.Join(allTypes, "`, `"))
 		}
 	}
 	return nil

--- a/lib/lib.go
+++ b/lib/lib.go
@@ -34,7 +34,7 @@ func CheckType(types []string) error {
 	}
 	for _, t := range types {
 		if !contains(allTypes, t) {
-			return fmt.Errorf("type %s is not valid. Possible values are: `%s`", t, strings.Join(allTypes, "`, `"))
+			return fmt.Errorf("type `%s` is not valid. Possible values are: `%s`", t, strings.Join(allTypes, "`, `"))
 		}
 	}
 	return nil


### PR DESCRIPTION
# Before
Error: type cat is not valid. Possible values are: adjectives, `colours, `dogs, `gladiators, `greek, `marvel, `materials, `trees

# After
Error: type `cat` is not valid. Possible values are: `adjectives`, `colours`, `dogs`, `gladiators`, `greek`, `marvel`, `materials`, `trees`